### PR TITLE
Fix concurrency issue with results processing.

### DIFF
--- a/core.py
+++ b/core.py
@@ -51,7 +51,8 @@ def mp_handler():
 
     p = multiprocessing.Pool(multiprocessing.cpu_count())
     while queue.qsize():
-        result = p.apply_async(worker, )
+        p.apply_async(worker, )
+    queue.join()
 
 
 def worker():
@@ -192,7 +193,7 @@ def folder_reader(path):
 
                 # check if it is archive
                 if filename in EXCLUDED_FILES or extension in EXCLUDED_FILES:
-                    # remove unnecesarry files
+                    # remove unnecessary files
                     if REMOVE_FLAG:
                         _file = root + '/' + filename
                         remove_file(_file)
@@ -314,7 +315,7 @@ def save_output():
             json.dump(data, f)
 
     except Exception as e:
-        logger.error("while trying to write to " + str(_file) + " file. Details:\n" + str(e))
+        logger.error("while trying to write to " + str(OUTFILE) + " file. Details:\n" + str(e))
 
 
 def password_search(line):


### PR DESCRIPTION
Found one confusing issue in tool executing process.
**Environment**: MacOs 10.14.6, python 3.7
**Command**:
`python DumpsterDiver.py -p /testSources/ -a --entropy 3 --grep-words '*.setSecure(false)*'`

**Description**: In example below and by test data files I have say 4 issues, 3 of them are Hardcoded tokens and 1 grep finding(`.setSecure(false)`). Due to concurrency issues results in json output file of your tool  are unstable. Grep results sometimes are missing there. Though there are present in console output.
**Investigated**: issue comes from concurrent access of queue object, where we checking queue.qsize() that is unreliable due to documentation. And there is a case where main thread is finishing, while queue is still in process. So we do not write some part of results into json report file. 
**Solution**: synch/wait for queue result before finishing main thread. See proposed fix below. 

Minor notes: also fixed other issue noted, with wrong file name in exception section. And one misspelled word in some other place. 