### PR TITLE
Windows fixes

### DIFF
--- a/DumpsterDiver.py
+++ b/DumpsterDiver.py
@@ -6,6 +6,8 @@ import os
 import sys
 import argparse
 from termcolor import colored
+import colorama
+colorama.init()
 
 
 #Borrowed from https://bitbucket.org/ruamel/std.argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 termcolor==1.1.0
+colorama==0.4.3
 passwordmeter==0.1.8
 PyYAML==5.1


### PR DESCRIPTION
Fixes #20 and also colors.

This was hacked together just to get it running, and has not been thoroughly tested. "It works on my machine!"

For multiprocessing on Windows, the commit message summarizes the change:
> Because Windows relies on `spawn` instead of `fork`, the main module gets
> imported again. Anything run outside of `if __name__ == '__main__'` will be
> executed again.
>
> See:
> https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
> https://stackoverflow.com/a/18205006/
 

For colors, see this description and alternative approach from the [colorama doc](https://pypi.org/project/colorama/):
> Colorama makes this work on Windows, too, by wrapping stdout, stripping ANSI sequences it finds (which would appear as gobbledygook in the output), and converting them into the appropriate win32 calls to modify the state of the terminal. On other platforms, Colorama does nothing.
> An alternative approach is to install ansi.sys on Windows machines, which provides the same behaviour for all applications running in terminals. Colorama is intended for situations where that isn’t easy (e.g., maybe your app doesn’t have an installer.)