### PR TITLE
Fixing python multiprocessing errors

### DIFF
--- a/core.py
+++ b/core.py
@@ -45,6 +45,7 @@ def mp_handler(queue, result, settings):
 
     p = multiprocessing.Pool(multiprocessing.cpu_count())
     while queue.qsize():
+        time.sleep(1)
         p.apply_async(worker, (queue,result,settings))
     queue.join()
 


### PR DESCRIPTION
Following workaround suggested in #43 to avoid concurrency issues.